### PR TITLE
Add gulp-rename to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"devDependencies": {
+  "devDependencies": {
     "gulp": "^3.8.5",
     "gulp-autoprefixer": "0.0.8",
     "gulp-concat": "^2.4.1",
@@ -8,6 +8,7 @@
     "gulp-minify-css": "^0.3.6",
     "gulp-notify": "^1.4.0",
     "gulp-plumber": "^0.6.3",
+    "gulp-rename": "^1.2.2",
     "gulp-sass": "^0.7.2",
     "gulp-uglify": "^1.0.1",
     "gulp-watch": "^0.6.8"


### PR DESCRIPTION
Fixes `gulp` error stating `gulp-rename` could not be found. Error below for reference.

```
module.js:338
    throw err;
          ^
Error: Cannot find module 'gulp-rename'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/Chris/wp-units/gulpfile.js:10:14)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
```
